### PR TITLE
Add tld-permutation for ALL domains not just original

### DIFF
--- a/DNSrazzle.py
+++ b/DNSrazzle.py
@@ -254,6 +254,13 @@ class DnsRazzle():
     def gen(self, shouldPrint=False):
         fuzz = dnstwist.DomainFuzz(self.domain, self.dictionary, self.tld)
         fuzz.generate()
+        if self.tld is not None:
+            for entry in fuzz.domains.copy():
+                for tld in self.tld:
+                    new_domain = ".".join(entry["domain-name"].split(".")[:-1]) + "." + tld;
+                    fuzz.domains.append({"fuzzer": 'tld-swap', "domain-name": new_domain})
+            m = getattr(fuzz, "_DomainFuzz__postprocess")
+            m()
         if shouldPrint:
             for entry in fuzz.domains[1:]:
                 print(entry['domain-name'])


### PR DESCRIPTION
The --tld flag asks DNSTwist to permute the TLDs but it only does that for the original (base) domain.
This will permute all domains created by DNSTwist.
Warning -- this can blow up the number of domains you have to check!