### PR TITLE
Fix syntax in requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ opencv-python-headless
 numpy
 python-nmap
 argparse
-dnstwist=20201228
+dnstwist==20201228
 progress
 reconDNS>=0.0.3


### PR DESCRIPTION
My python 3.8 pip complained about the single equals sign.