### PR TITLE
fixed switch is always flipped but with arg parse

### DIFF
--- a/DNSrazzle.py
+++ b/DNSrazzle.py
@@ -70,7 +70,7 @@ def main():
                         help='Perform nmap scan on discovered domains.')
     parser.add_argument('-N', '--ns', dest='nameserver', metavar='STRING', type=str, default='1.1.1.1',
                         help='Specify DNS nameserver to use for DNS queries')
-    parser.add_argument('--noss', dest='no_screenshot', action='store_true', default=True,
+    parser.add_argument('--noss', dest='no_screenshot', action='store_true',
                         help='Do not take screenshots of discovered domains.  Only collect DNS and banner info')
     parser.add_argument('-o', '--out-directory', type=str, dest='out_dir', default=None,
                         help='Absolute path of directory to output reports to.  Will be created if doesn\'t exist.')


### PR DESCRIPTION
so that 'default=true' flag means if you don't set the flag fefault its value to true but then when we set the flag we set its value to true so there was no possible false condition